### PR TITLE
Task 3: SQLite設定マネージャの実装

### DIFF
--- a/slack_talk/core/config.py
+++ b/slack_talk/core/config.py
@@ -1,0 +1,213 @@
+"""SQLite configuration manager."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import aiosqlite
+
+from slack_talk.core.models import AudioSettings, ChannelConfig, DisplaySettings, VoiceSettings
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS channels (
+    channel_id TEXT PRIMARY KEY,
+    channel_name TEXT NOT NULL,
+    tts_enabled INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS audio_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    speech_rate REAL NOT NULL DEFAULT 1.0,
+    volume REAL NOT NULL DEFAULT 0.8,
+    queue_ttl_seconds INTEGER NOT NULL DEFAULT 300,
+    retry_count INTEGER NOT NULL DEFAULT 2,
+    flow_matching_steps INTEGER NOT NULL DEFAULT 10,
+    reference_audio_path TEXT
+);
+
+CREATE TABLE IF NOT EXISTS voice_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    wakeword TEXT NOT NULL DEFAULT 'OK Slack',
+    silence_threshold_seconds REAL NOT NULL DEFAULT 1.5,
+    input_device INTEGER,
+    output_device INTEGER,
+    default_channel_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS display_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    theme TEXT NOT NULL DEFAULT 'dark',
+    thread_preview_count INTEGER NOT NULL DEFAULT 2,
+    priority_rules TEXT NOT NULL DEFAULT '{}'
+);
+"""
+
+_SEED = """
+INSERT OR IGNORE INTO audio_settings (id) VALUES (1);
+INSERT OR IGNORE INTO voice_settings (id) VALUES (1);
+INSERT OR IGNORE INTO display_settings (id) VALUES (1);
+"""
+
+
+class ConfigManager:
+    def __init__(self, db_path: str = "slack_talk.db") -> None:
+        self._db_path = db_path
+        self._db: aiosqlite.Connection | None = None
+
+    async def initialize(self) -> None:
+        self._db = await aiosqlite.connect(self._db_path)
+        self._db.row_factory = aiosqlite.Row
+        await self._db.executescript(_SCHEMA)
+        await self._db.executescript(_SEED)
+        await self._db.commit()
+        logger.info("ConfigManager initialized: %s", self._db_path)
+
+    async def close(self) -> None:
+        if self._db:
+            await self._db.close()
+
+    @property
+    def db(self) -> aiosqlite.Connection:
+        assert self._db is not None, "ConfigManager not initialized"
+        return self._db
+
+    # --- Channels ---
+
+    async def get_all_channels(self) -> list[ChannelConfig]:
+        async with self.db.execute("SELECT * FROM channels") as cur:
+            rows = await cur.fetchall()
+        return [
+            ChannelConfig(
+                channel_id=r["channel_id"],
+                channel_name=r["channel_name"],
+                tts_enabled=bool(r["tts_enabled"]),
+            )
+            for r in rows
+        ]
+
+    async def get_enabled_channels(self) -> list[ChannelConfig]:
+        async with self.db.execute(
+            "SELECT * FROM channels WHERE tts_enabled = 1"
+        ) as cur:
+            rows = await cur.fetchall()
+        return [
+            ChannelConfig(
+                channel_id=r["channel_id"],
+                channel_name=r["channel_name"],
+                tts_enabled=True,
+            )
+            for r in rows
+        ]
+
+    async def get_channel(self, channel_id: str) -> ChannelConfig | None:
+        async with self.db.execute(
+            "SELECT * FROM channels WHERE channel_id = ?", (channel_id,)
+        ) as cur:
+            r = await cur.fetchone()
+        if r is None:
+            return None
+        return ChannelConfig(
+            channel_id=r["channel_id"],
+            channel_name=r["channel_name"],
+            tts_enabled=bool(r["tts_enabled"]),
+        )
+
+    async def upsert_channel(self, ch: ChannelConfig) -> None:
+        await self.db.execute(
+            """INSERT INTO channels (channel_id, channel_name, tts_enabled)
+               VALUES (?, ?, ?)
+               ON CONFLICT(channel_id)
+               DO UPDATE SET channel_name=excluded.channel_name,
+                             tts_enabled=excluded.tts_enabled""",
+            (ch.channel_id, ch.channel_name, int(ch.tts_enabled)),
+        )
+        await self.db.commit()
+
+    # --- Audio Settings ---
+
+    async def get_audio_settings(self) -> AudioSettings:
+        async with self.db.execute(
+            "SELECT * FROM audio_settings WHERE id = 1"
+        ) as cur:
+            r = await cur.fetchone()
+        return AudioSettings(
+            speech_rate=r["speech_rate"],
+            volume=r["volume"],
+            queue_ttl_seconds=r["queue_ttl_seconds"],
+            retry_count=r["retry_count"],
+            flow_matching_steps=r["flow_matching_steps"],
+            reference_audio_path=r["reference_audio_path"],
+        )
+
+    async def save_audio_settings(self, s: AudioSettings) -> None:
+        await self.db.execute(
+            """UPDATE audio_settings SET
+               speech_rate=?, volume=?, queue_ttl_seconds=?,
+               retry_count=?, flow_matching_steps=?, reference_audio_path=?
+               WHERE id = 1""",
+            (
+                s.speech_rate,
+                s.volume,
+                s.queue_ttl_seconds,
+                s.retry_count,
+                s.flow_matching_steps,
+                s.reference_audio_path,
+            ),
+        )
+        await self.db.commit()
+
+    # --- Voice Settings ---
+
+    async def get_voice_settings(self) -> VoiceSettings:
+        async with self.db.execute(
+            "SELECT * FROM voice_settings WHERE id = 1"
+        ) as cur:
+            r = await cur.fetchone()
+        return VoiceSettings(
+            wakeword=r["wakeword"],
+            silence_threshold_seconds=r["silence_threshold_seconds"],
+            input_device=r["input_device"],
+            output_device=r["output_device"],
+            default_channel_id=r["default_channel_id"],
+        )
+
+    async def save_voice_settings(self, s: VoiceSettings) -> None:
+        await self.db.execute(
+            """UPDATE voice_settings SET
+               wakeword=?, silence_threshold_seconds=?,
+               input_device=?, output_device=?, default_channel_id=?
+               WHERE id = 1""",
+            (
+                s.wakeword,
+                s.silence_threshold_seconds,
+                s.input_device,
+                s.output_device,
+                s.default_channel_id,
+            ),
+        )
+        await self.db.commit()
+
+    # --- Display Settings ---
+
+    async def get_display_settings(self) -> DisplaySettings:
+        async with self.db.execute(
+            "SELECT * FROM display_settings WHERE id = 1"
+        ) as cur:
+            r = await cur.fetchone()
+        return DisplaySettings(
+            theme=r["theme"],
+            thread_preview_count=r["thread_preview_count"],
+            priority_rules=json.loads(r["priority_rules"]),
+        )
+
+    async def save_display_settings(self, s: DisplaySettings) -> None:
+        await self.db.execute(
+            """UPDATE display_settings SET
+               theme=?, thread_preview_count=?, priority_rules=?
+               WHERE id = 1""",
+            (s.theme, s.thread_preview_count, json.dumps(s.priority_rules)),
+        )
+        await self.db.commit()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,97 @@
+"""Tests for SQLite config manager."""
+
+import os
+import tempfile
+
+import pytest
+
+from slack_talk.core.config import ConfigManager
+from slack_talk.core.models import AudioSettings, ChannelConfig, DisplaySettings, VoiceSettings
+
+
+@pytest.fixture
+async def config_manager():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    manager = ConfigManager(db_path)
+    await manager.initialize()
+    yield manager
+    await manager.close()
+    os.unlink(db_path)
+
+
+class TestConfigManagerInit:
+    async def test_initialize_creates_tables(self, config_manager: ConfigManager):
+        # Should not raise
+        channels = await config_manager.get_all_channels()
+        assert channels == []
+
+
+class TestChannelConfig:
+    async def test_upsert_and_get_channel(self, config_manager: ConfigManager):
+        ch = ChannelConfig(channel_id="C123", channel_name="general", tts_enabled=True)
+        await config_manager.upsert_channel(ch)
+        result = await config_manager.get_channel("C123")
+        assert result is not None
+        assert result.channel_name == "general"
+        assert result.tts_enabled is True
+
+    async def test_get_channel_not_found(self, config_manager: ConfigManager):
+        result = await config_manager.get_channel("CXXX")
+        assert result is None
+
+    async def test_get_enabled_channels(self, config_manager: ConfigManager):
+        await config_manager.upsert_channel(
+            ChannelConfig("C1", "general", tts_enabled=True)
+        )
+        await config_manager.upsert_channel(
+            ChannelConfig("C2", "random", tts_enabled=False)
+        )
+        await config_manager.upsert_channel(
+            ChannelConfig("C3", "dev", tts_enabled=True)
+        )
+        enabled = await config_manager.get_enabled_channels()
+        assert len(enabled) == 2
+        ids = {ch.channel_id for ch in enabled}
+        assert ids == {"C1", "C3"}
+
+
+class TestAudioSettings:
+    async def test_default_audio_settings(self, config_manager: ConfigManager):
+        settings = await config_manager.get_audio_settings()
+        assert settings.speech_rate == 1.0
+        assert settings.volume == 0.8
+
+    async def test_save_and_get_audio_settings(self, config_manager: ConfigManager):
+        settings = AudioSettings(speech_rate=1.5, volume=0.6, retry_count=3)
+        await config_manager.save_audio_settings(settings)
+        result = await config_manager.get_audio_settings()
+        assert result.speech_rate == 1.5
+        assert result.volume == 0.6
+        assert result.retry_count == 3
+
+
+class TestVoiceSettings:
+    async def test_default_voice_settings(self, config_manager: ConfigManager):
+        settings = await config_manager.get_voice_settings()
+        assert settings.wakeword == "OK Slack"
+
+    async def test_save_and_get_voice_settings(self, config_manager: ConfigManager):
+        settings = VoiceSettings(wakeword="Hey Slack", silence_threshold_seconds=2.0)
+        await config_manager.save_voice_settings(settings)
+        result = await config_manager.get_voice_settings()
+        assert result.wakeword == "Hey Slack"
+        assert result.silence_threshold_seconds == 2.0
+
+
+class TestDisplaySettings:
+    async def test_default_display_settings(self, config_manager: ConfigManager):
+        settings = await config_manager.get_display_settings()
+        assert settings.theme == "dark"
+
+    async def test_save_and_get_display_settings(self, config_manager: ConfigManager):
+        settings = DisplaySettings(theme="light", thread_preview_count=3)
+        await config_manager.save_display_settings(settings)
+        result = await config_manager.get_display_settings()
+        assert result.theme == "light"
+        assert result.thread_preview_count == 3


### PR DESCRIPTION
## 概要
aiosqlite を使用した設定永続化マネージャ（ConfigManager）の実装。

## 変更内容
- `slack_talk/core/config.py` — ConfigManager クラス（4テーブル、CRUD操作）
- `tests/core/test_config.py` — 10テストケース（全PASS）

## テーブル構成
- `channels` — チャンネル別TTS有効/無効
- `audio_settings` — 音声合成設定（シングルトン）
- `voice_settings` — 音声入力設定（シングルトン）
- `display_settings` — 表示設定（シングルトン）

## テスト結果
- `poetry run pytest tests/core/ -v` → 20 passed（既存10 + 新規10）

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)